### PR TITLE
EmailCommand for v1.3

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -323,11 +323,11 @@ Format: `email`
     the contents. +
     Type `next` to move on to the next step.
 
-    WARNING: Recipients and contents must be contrasting - If recipients are candidates, then
-    the content must be job offers and vice versa.
-
 .   *Sending your email.* Once both recipients and contents have been picked, type `send` to send your email. +
     This step is a confirmation step before you actually send the email.
+
+WARNING: Recipients and contents must be contrasting - If recipients are candidates, then the
+content must be job offers and vice versa.
 
 Examples:
 

--- a/src/main/java/seedu/recruit/commons/core/EmailSettings.java
+++ b/src/main/java/seedu/recruit/commons/core/EmailSettings.java
@@ -1,0 +1,52 @@
+package seedu.recruit.commons.core;
+
+import java.io.Serializable;
+
+public class EmailSettings implements Serializable {
+
+    private static final String DEFAULT_SUBJECT_CANDIDATE_AS_RECIPIENT = "New job offers that I have found for you!";
+    private static final String DEFAULT_SUBJECT_COMPANY_AS_RECIPEINT = "New candidates found for your company!";
+    private static final String DEFAULT_BODYTEXT_CANDIDATE_AS_RECIPIENT = "Dear candidate,\n"
+            + "I think you will be interested in these job offers!";
+    private static final String DEFAULT_BODYTEXT_COMPANY_AS_RECIPIENT = "Dear Sir/Madam,\n"
+            + "I think you will be interested in these candidates.";
+
+    private final String subjectCandidateAsRecipient;
+    private final String subjectCompanyAsRecipient;
+    private final String bodyTextCandidateAsRecipient;
+    private final String bodyTextCompanyAsRecipient;
+
+
+    public EmailSettings() {
+        subjectCandidateAsRecipient = DEFAULT_SUBJECT_CANDIDATE_AS_RECIPIENT;
+        subjectCompanyAsRecipient = DEFAULT_SUBJECT_COMPANY_AS_RECIPEINT;
+        bodyTextCandidateAsRecipient = DEFAULT_BODYTEXT_CANDIDATE_AS_RECIPIENT;
+        bodyTextCompanyAsRecipient = DEFAULT_BODYTEXT_COMPANY_AS_RECIPIENT;
+    }
+
+    public String getSubjectCandidateAsRecipient() {
+        return subjectCandidateAsRecipient;
+    }
+
+    public String getSubjectCompanyAsRecipient() {
+        return subjectCompanyAsRecipient;
+    }
+
+    public String getBodyTextCandidateAsRecipient() {
+        return bodyTextCandidateAsRecipient;
+    }
+
+    public String getBodyTextCompanyAsRecipient() {
+        return bodyTextCompanyAsRecipient;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder output = new StringBuilder();
+        output.append("Subject for Candidates as recipients : " + subjectCandidateAsRecipient + "\n");
+        output.append("Subject for Companies as recipients : " + subjectCompanyAsRecipient + "\n");
+        output.append("Body text for Candidates as recipients : " + bodyTextCandidateAsRecipient + "\n");
+        output.append("Body text for Companies as recipients : " + bodyTextCompanyAsRecipient);
+        return output.toString();
+    }
+}

--- a/src/main/java/seedu/recruit/commons/core/EmailSettings.java
+++ b/src/main/java/seedu/recruit/commons/core/EmailSettings.java
@@ -2,6 +2,9 @@ package seedu.recruit.commons.core;
 
 import java.io.Serializable;
 
+/**
+ * Stores settings for email command. Can be changed in preferences.json
+ */
 public class EmailSettings implements Serializable {
 
     private static final String DEFAULT_SUBJECT_CANDIDATE_AS_RECIPIENT = "New job offers that I have found for you!";
@@ -16,12 +19,21 @@ public class EmailSettings implements Serializable {
     private final String bodyTextCandidateAsRecipient;
     private final String bodyTextCompanyAsRecipient;
 
-
     public EmailSettings() {
         subjectCandidateAsRecipient = DEFAULT_SUBJECT_CANDIDATE_AS_RECIPIENT;
         subjectCompanyAsRecipient = DEFAULT_SUBJECT_COMPANY_AS_RECIPEINT;
         bodyTextCandidateAsRecipient = DEFAULT_BODYTEXT_CANDIDATE_AS_RECIPIENT;
         bodyTextCompanyAsRecipient = DEFAULT_BODYTEXT_COMPANY_AS_RECIPIENT;
+    }
+
+    public EmailSettings(String subjectCandidateAsRecipient,
+                         String subjectCompanyAsRecipient,
+                         String bodyTextCandidateAsRecipient,
+                         String bodyTextCompanyAsRecipient) {
+        this.subjectCandidateAsRecipient = subjectCandidateAsRecipient;
+        this.subjectCompanyAsRecipient  = subjectCompanyAsRecipient;
+        this.bodyTextCandidateAsRecipient = bodyTextCandidateAsRecipient;
+        this.bodyTextCompanyAsRecipient = bodyTextCompanyAsRecipient;
     }
 
     public String getSubjectCandidateAsRecipient() {

--- a/src/main/java/seedu/recruit/commons/util/EmailUtil.java
+++ b/src/main/java/seedu/recruit/commons/util/EmailUtil.java
@@ -43,6 +43,10 @@ public class EmailUtil {
      * If modifying these scopes, delete your previously saved tokens/ folder.
      */
     public static final String DEFAULT_FROM = "cs2113.f09.4@gmail.com";
+    public static final String EMAIL_ADD_COMMAND = "add";
+    public static final String EMAIL_NEXT_COMMAND = "next";
+    public static final String EMAIL_BACK_COMMAND = "back";
+    public static final String EMAIL_SEND_COMMAND = "send";
     private static final String APPLICATION_NAME = "CS2113 F09 T04";
     private static final String TOKENS_DIRECTORY_PATH = "tokens";
     private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();

--- a/src/main/java/seedu/recruit/commons/util/EmailUtil.java
+++ b/src/main/java/seedu/recruit/commons/util/EmailUtil.java
@@ -56,10 +56,10 @@ public class EmailUtil {
     /**
      * Variables for Email Command
      */
+    private static EmailSettings emailSettings;
     private ArrayList<Candidate> candidates;
     private ArrayList<JobOffer> jobOffers;
     private boolean areRecipientsCandidates;
-    private static EmailSettings emailSettings;
 
     /**
      * Constructor

--- a/src/main/java/seedu/recruit/commons/util/EmailUtil.java
+++ b/src/main/java/seedu/recruit/commons/util/EmailUtil.java
@@ -30,6 +30,7 @@ import com.google.api.services.gmail.Gmail;
 import com.google.api.services.gmail.GmailScopes;
 import com.google.api.services.gmail.model.Message;
 
+import seedu.recruit.commons.core.EmailSettings;
 import seedu.recruit.model.candidate.Candidate;
 import seedu.recruit.model.joboffer.JobOffer;
 
@@ -54,16 +55,15 @@ public class EmailUtil {
     private ArrayList<Candidate> candidates;
     private ArrayList<JobOffer> jobOffers;
     private boolean areRecipientsCandidates;
-    private String to;
-    private String subject;
-    private String bodyText;
+    private final EmailSettings emailSettings;
 
     /**
      * Constructor
      */
-    public EmailUtil() {
+    public EmailUtil(EmailSettings emailSettings) {
         this.candidates = new ArrayList<>();
         this.jobOffers = new ArrayList<>();
+        this.emailSettings = emailSettings;
     }
 
     /**
@@ -93,28 +93,8 @@ public class EmailUtil {
         this.areRecipientsCandidates = areRecipientsCandidates;
     }
 
-    public String getTo() {
-        return to;
-    }
-
-    public void setTo(String to) {
-        this.to = to;
-    }
-
-    public String getSubject() {
-        return subject;
-    }
-
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
-
-    public String getBodyText() {
-        return bodyText;
-    }
-
-    public void setBodyText(String bodyText) {
-        this.bodyText = bodyText;
+    public EmailSettings getEmailSettings() {
+        return emailSettings;
     }
 
     /**

--- a/src/main/java/seedu/recruit/commons/util/EmailUtil.java
+++ b/src/main/java/seedu/recruit/commons/util/EmailUtil.java
@@ -132,6 +132,7 @@ public class EmailUtil {
     public void addJobOffer(JobOffer jobOffer) {
         this.jobOffers.add(jobOffer);
     }
+
     /**
      * Creates an authorized Credential object.
      * @param httpTransport The network HTTP Transport.

--- a/src/main/java/seedu/recruit/commons/util/EmailUtil.java
+++ b/src/main/java/seedu/recruit/commons/util/EmailUtil.java
@@ -55,20 +55,23 @@ public class EmailUtil {
     private ArrayList<Candidate> candidates;
     private ArrayList<JobOffer> jobOffers;
     private boolean areRecipientsCandidates;
-    private final EmailSettings emailSettings;
+    private static EmailSettings emailSettings;
 
     /**
      * Constructor
      */
-    public EmailUtil(EmailSettings emailSettings) {
+    public EmailUtil() {
         this.candidates = new ArrayList<>();
         this.jobOffers = new ArrayList<>();
-        this.emailSettings = emailSettings;
     }
-
     /**
      * Getters and Setters
      */
+    public static void setEmailSettings(EmailSettings emailSettings) {
+        EmailUtil.emailSettings = emailSettings;
+    }
+
+
     public ArrayList<Candidate> getCandidates() {
         return candidates;
     }

--- a/src/main/java/seedu/recruit/logic/commands/Command.java
+++ b/src/main/java/seedu/recruit/logic/commands/Command.java
@@ -5,6 +5,7 @@ import java.security.GeneralSecurityException;
 
 import seedu.recruit.logic.CommandHistory;
 import seedu.recruit.logic.commands.exceptions.CommandException;
+import seedu.recruit.logic.parser.exceptions.ParseException;
 import seedu.recruit.model.Model;
 
 /**
@@ -23,6 +24,6 @@ public abstract class Command {
      * @throws GeneralSecurityException Something to do with email command
      */
     public abstract CommandResult execute(Model model, CommandHistory history)
-            throws CommandException, IOException, GeneralSecurityException;
+            throws CommandException, IOException, GeneralSecurityException, ParseException;
 
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailInitialiseCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailInitialiseCommand.java
@@ -10,7 +10,7 @@ import seedu.recruit.logic.commands.CommandResult;
 import seedu.recruit.model.Model;
 
 /**
- * Starts the 3-step process of Email
+ * Starts the 4-step process of Email
  */
 public class EmailInitialiseCommand extends Command {
     public static final String COMMAND_WORD = "email";

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailInitialiseCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailInitialiseCommand.java
@@ -22,7 +22,7 @@ public class EmailInitialiseCommand extends Command {
         requireNonNull(model);
 
         //Initiailising a fresh instance of EmailUtil
-        EmailUtil emailUtil = new EmailUtil(model.getEmailUtil().getEmailSettings());
+        EmailUtil emailUtil = new EmailUtil();
         model.setEmailUtil(emailUtil);
         LogicManager.setLogicState(EmailSelectRecipientsCommand.COMMAND_LOGIC_STATE);
         return new CommandResult(EmailSelectRecipientsCommand.MESSAGE_USAGE);

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailInitialiseCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailInitialiseCommand.java
@@ -22,7 +22,7 @@ public class EmailInitialiseCommand extends Command {
         requireNonNull(model);
 
         //Initiailising a fresh instance of EmailUtil
-        EmailUtil emailUtil = new EmailUtil();
+        EmailUtil emailUtil = new EmailUtil(model.getEmailUtil().getEmailSettings());
         model.setEmailUtil(emailUtil);
         LogicManager.setLogicState(EmailSelectRecipientsCommand.COMMAND_LOGIC_STATE);
         return new CommandResult(EmailSelectRecipientsCommand.MESSAGE_USAGE);

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -1,6 +1,7 @@
 package seedu.recruit.logic.commands.emailcommand;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.recruit.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import javafx.collections.ObservableList;
 import seedu.recruit.commons.util.EmailUtil;
@@ -8,6 +9,7 @@ import seedu.recruit.logic.CommandHistory;
 import seedu.recruit.logic.LogicManager;
 import seedu.recruit.logic.commands.Command;
 import seedu.recruit.logic.commands.CommandResult;
+import seedu.recruit.logic.parser.exceptions.ParseException;
 import seedu.recruit.model.Model;
 import seedu.recruit.model.candidate.Candidate;
 import seedu.recruit.model.joboffer.JobOffer;
@@ -31,12 +33,12 @@ public class EmailSelectContentsCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) {
+    public CommandResult execute(Model model, CommandHistory history) throws ParseException {
         requireNonNull(model);
         EmailUtil emailUtil = model.getEmailUtil();
 
         //Add contents only if commandWord equals add
-        if (commandWord.equals("add")) {
+        if (commandWord.equals(EmailUtil.EMAIL_ADD_COMMAND)) {
             if (emailUtil.isAreRecipientsCandidates()) {
                 ObservableList<JobOffer> contents = model.getFilteredCompanyJobList();
                 for (JobOffer content : contents) {
@@ -58,7 +60,7 @@ public class EmailSelectContentsCommand extends Command {
             output += EmailSelectRecipientsCommand.MESSAGE_USAGE;
             return new CommandResult(output);
 
-        } else if (commandWord.equals("next")) {
+        } else if (commandWord.equals(EmailUtil.EMAIL_NEXT_COMMAND)) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
 
@@ -79,9 +81,11 @@ public class EmailSelectContentsCommand extends Command {
                 return new CommandResult(EmailSendCommand.MESSAGE_USAGE);
             }
         //back command
-        } else {
+        } else if (commandWord.equals(EmailUtil.EMAIL_BACK_COMMAND)) {
             LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
             return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
         }
+
+        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -17,28 +17,40 @@ import seedu.recruit.model.joboffer.JobOffer;
  */
 public class EmailSelectContentsCommand extends Command {
     public static final String COMMAND_WORD = "next";
-    public static final String MESSAGE_USAGE = "Find the content that you are going to email\n"
-            + "Type \"next\" when you have done so to move on to the next step.";
+    public static final String MESSAGE_USAGE = "Find the contents that you are going to email recipients about.\n"
+            + "All items listed below will be added into the contents field.\n"
+            + "Find/Filter the contents you intend to email, then type \"add\" to add contents to the field.\n"
+            + "Type \"next\" when you have finished adding contents to move on to the next step.";
     public static final String COMMAND_LOGIC_STATE = "EmailSelectContents";
+    private final String commandWord;
+
+    public EmailSelectContentsCommand(String commandWord) {
+        this.commandWord = commandWord;
+    }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        EmailUtil emailUtil = model.getEmailUtil();
 
-        if (emailUtil.isAreRecipientsCandidates()) {
-            ObservableList<JobOffer> contents = model.getFilteredCompanyJobList();
-            for (JobOffer content : contents) {
-                emailUtil.addJobOffer(content);
+        //Add contents only if commandWord equals add
+        if(commandWord.equals("add")) {
+            EmailUtil emailUtil = model.getEmailUtil();
+
+            if (emailUtil.isAreRecipientsCandidates()) {
+                ObservableList<JobOffer> contents = model.getFilteredCompanyJobList();
+                for (JobOffer content : contents) {
+                    emailUtil.addJobOffer(content);
+                }
+            } else {
+                ObservableList<Candidate> contents = model.getFilteredCandidateList();
+                for (Candidate content : contents) {
+                    emailUtil.addCandidate(content);
+                }
             }
+            return new CommandResult("Contents added!\n" + EmailSelectContentsCommand.MESSAGE_USAGE);
         } else {
-            ObservableList<Candidate> contents = model.getFilteredCandidateList();
-            for (Candidate content : contents) {
-                emailUtil.addCandidate(content);
-            }
+            LogicManager.setLogicState(EmailSendCommand.COMMAND_LOGIC_STATE);
+            return new CommandResult(EmailSendCommand.MESSAGE_USAGE);
         }
-
-        LogicManager.setLogicState(EmailSendCommand.COMMAND_LOGIC_STATE);
-        return new CommandResult(EmailSendCommand.MESSAGE_USAGE);
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -13,14 +13,16 @@ import seedu.recruit.model.candidate.Candidate;
 import seedu.recruit.model.joboffer.JobOffer;
 
 /**
- * 3rd step of the Email command
+ * 3rd step of the Email command: selecting contents
  */
 public class EmailSelectContentsCommand extends Command {
     public static final String COMMAND_WORD = "next";
-    public static final String MESSAGE_USAGE = "Find the contents that you are going to email recipients about.\n"
+    public static final String MESSAGE_USAGE = "Find/Filter the contents you intend to email. "
             + "All items listed below will be added into the contents field.\n"
-            + "Find/Filter the contents you intend to email, then type \"add\" to add contents to the field.\n"
-            + "Type \"next\" when you have finished adding contents to move on to the next step.";
+            + "Type \"add\" to add contents to the field.\n"
+            + "Type \"next\" when you have finished adding contents to move on to the next step.\n"
+            + "Type \"back\" to return to select recipients command.\n"
+            + "Type \"cancel\" to cancel the email command.";
     public static final String COMMAND_LOGIC_STATE = "EmailSelectContents";
     private final String commandWord;
 
@@ -46,15 +48,16 @@ public class EmailSelectContentsCommand extends Command {
                     emailUtil.addCandidate(content);
                 }
             }
+
+            String output = "Content added:\n";
             if(emailUtil.isAreRecipientsCandidates()) {
-                return new CommandResult("Content added:\n"
-                        + model.getFilteredContentJobOfferNames()
-                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+                output += model.getFilteredContentJobOfferNames();
             } else {
-                return new CommandResult("Content added:\n"
-                        + model.getFilteredCandidateNames()
-                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+                output += model.getFilteredCandidateNames();
             }
+            output += EmailSelectRecipientsCommand.MESSAGE_USAGE;
+            return new CommandResult(output);
+
         } else if(commandWord.equals("next")) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
@@ -69,7 +72,7 @@ public class EmailSelectContentsCommand extends Command {
             }
 
             if(isEmpty) {
-                return new CommandResult("There are no contents selected!\n"
+                return new CommandResult("ERROR: There are no contents selected!\n"
                         + EmailSelectContentsCommand.MESSAGE_USAGE);
             } else {
                 LogicManager.setLogicState(EmailSendCommand.COMMAND_LOGIC_STATE);

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -31,11 +31,10 @@ public class EmailSelectContentsCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
+        EmailUtil emailUtil = model.getEmailUtil();
 
         //Add contents only if commandWord equals add
         if(commandWord.equals("add")) {
-            EmailUtil emailUtil = model.getEmailUtil();
-
             if (emailUtil.isAreRecipientsCandidates()) {
                 ObservableList<JobOffer> contents = model.getFilteredCompanyJobList();
                 for (JobOffer content : contents) {
@@ -49,8 +48,25 @@ public class EmailSelectContentsCommand extends Command {
             }
             return new CommandResult("Contents added!\n" + EmailSelectContentsCommand.MESSAGE_USAGE);
         } else {
-            LogicManager.setLogicState(EmailSendCommand.COMMAND_LOGIC_STATE);
-            return new CommandResult(EmailSendCommand.MESSAGE_USAGE);
+            //Check if content array is empty, if it is, do not allow to move on to next stage
+            boolean isEmpty = false;
+
+            //if recipient are candidates and job offers arraylist is empty
+            if (emailUtil.isAreRecipientsCandidates() && emailUtil.getJobOffers().size() == 0) {
+                isEmpty = true;
+            }
+            //if companies are candidates and candidates arraylist is empty
+            if (!emailUtil.isAreRecipientsCandidates() && emailUtil.getCandidates().size() == 0) {
+                isEmpty = true;
+            }
+
+            if(isEmpty) {
+                return new CommandResult("There are no contents selected!\n"
+                        + EmailSelectContentsCommand.MESSAGE_USAGE);
+            } else {
+                LogicManager.setLogicState(EmailSendCommand.COMMAND_LOGIC_STATE);
+                return new CommandResult(EmailSendCommand.MESSAGE_USAGE);
+            }
         }
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -46,7 +46,15 @@ public class EmailSelectContentsCommand extends Command {
                     emailUtil.addCandidate(content);
                 }
             }
-            return new CommandResult("Contents added!\n" + EmailSelectContentsCommand.MESSAGE_USAGE);
+            if(emailUtil.isAreRecipientsCandidates()) {
+                return new CommandResult("Content added:\n"
+                        + model.getFilteredContentJobOfferNames()
+                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+            } else {
+                return new CommandResult("Content added:\n"
+                        + model.getFilteredCandidateNames()
+                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+            }
         } else {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -50,7 +50,7 @@ public class EmailSelectContentsCommand extends Command {
             }
 
             String output = "Content added:\n";
-            if(emailUtil.isAreRecipientsCandidates()) {
+            if (emailUtil.isAreRecipientsCandidates()) {
                 output += model.getFilteredContentJobOfferNames();
             } else {
                 output += model.getFilteredCandidateNames();
@@ -58,7 +58,7 @@ public class EmailSelectContentsCommand extends Command {
             output += EmailSelectRecipientsCommand.MESSAGE_USAGE;
             return new CommandResult(output);
 
-        } else if(commandWord.equals("next")) {
+        } else if (commandWord.equals("next")) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
 
@@ -71,7 +71,7 @@ public class EmailSelectContentsCommand extends Command {
                 isEmpty = true;
             }
 
-            if(isEmpty) {
+            if (isEmpty) {
                 return new CommandResult("ERROR: There are no contents selected!\n"
                         + EmailSelectContentsCommand.MESSAGE_USAGE);
             } else {

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectContentsCommand.java
@@ -34,7 +34,7 @@ public class EmailSelectContentsCommand extends Command {
         EmailUtil emailUtil = model.getEmailUtil();
 
         //Add contents only if commandWord equals add
-        if(commandWord.equals("add")) {
+        if (commandWord.equals("add")) {
             if (emailUtil.isAreRecipientsCandidates()) {
                 ObservableList<JobOffer> contents = model.getFilteredCompanyJobList();
                 for (JobOffer content : contents) {
@@ -55,7 +55,7 @@ public class EmailSelectContentsCommand extends Command {
                         + model.getFilteredCandidateNames()
                         + EmailSelectRecipientsCommand.MESSAGE_USAGE);
             }
-        } else {
+        } else if(commandWord.equals("next")) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
 
@@ -75,6 +75,10 @@ public class EmailSelectContentsCommand extends Command {
                 LogicManager.setLogicState(EmailSendCommand.COMMAND_LOGIC_STATE);
                 return new CommandResult(EmailSendCommand.MESSAGE_USAGE);
             }
+        //back command
+        } else {
+            LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
+            return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
         }
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -32,11 +32,10 @@ public class EmailSelectRecipientsCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
+        EmailUtil emailUtil = model.getEmailUtil();
 
         //Add recipients only if commandWord is add.
         if(commandWord.equals("add")) {
-            EmailUtil emailUtil = model.getEmailUtil();
-
             if (MainWindow.getDisplayedBook().equals("candidateBook")) {
                 ObservableList<Candidate> recipients = model.getFilteredCandidateList();
                 for (Candidate recipient : recipients) {
@@ -52,8 +51,25 @@ public class EmailSelectRecipientsCommand extends Command {
             }
             return new CommandResult("Recipients added!\n" + EmailSelectRecipientsCommand.MESSAGE_USAGE);
         } else {
-            LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
-            return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
+            //Check if content array is empty, if it is, do not allow to move on to next stage
+            boolean isEmpty = false;
+
+            //if recipient are candidates and candidate arraylist is empty
+            if (emailUtil.isAreRecipientsCandidates() && emailUtil.getCandidates().size() == 0) {
+                isEmpty = true;
+            }
+            //if companies are candidates and job offers arraylist is empty
+            if (!emailUtil.isAreRecipientsCandidates() && emailUtil.getJobOffers().size() == 0) {
+                isEmpty = true;
+            }
+
+            if(isEmpty) {
+                return new CommandResult("There are no recipients selected!\n"
+                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+            } else {
+                LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
+                return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
+            }
         }
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -49,7 +49,16 @@ public class EmailSelectRecipientsCommand extends Command {
                 }
                 emailUtil.setAreRecipientsCandidates(false);
             }
-            return new CommandResult("Recipients added!\n" + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+
+            if(emailUtil.isAreRecipientsCandidates()) {
+                return new CommandResult("Recipients added:\n"
+                        + model.getFilteredCandidateNames()
+                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+            } else {
+                return new CommandResult("Recipients added:\n"
+                        + model.getFilteredRecipientJobOfferNames()
+                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+            }
         } else {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -4,12 +4,13 @@ import static java.util.Objects.requireNonNull;
 import static seedu.recruit.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import javafx.collections.ObservableList;
-import org.apache.http.ParseException;
+
 import seedu.recruit.commons.util.EmailUtil;
 import seedu.recruit.logic.CommandHistory;
 import seedu.recruit.logic.LogicManager;
 import seedu.recruit.logic.commands.Command;
 import seedu.recruit.logic.commands.CommandResult;
+import seedu.recruit.logic.parser.exceptions.ParseException;
 import seedu.recruit.model.Model;
 import seedu.recruit.model.candidate.Candidate;
 import seedu.recruit.model.joboffer.JobOffer;

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -1,8 +1,10 @@
 package seedu.recruit.logic.commands.emailcommand;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.recruit.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import javafx.collections.ObservableList;
+import org.apache.http.ParseException;
 import seedu.recruit.commons.util.EmailUtil;
 import seedu.recruit.logic.CommandHistory;
 import seedu.recruit.logic.LogicManager;
@@ -31,12 +33,12 @@ public class EmailSelectRecipientsCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory history) {
+    public CommandResult execute(Model model, CommandHistory history) throws ParseException {
         requireNonNull(model);
         EmailUtil emailUtil = model.getEmailUtil();
 
         //Add recipients only if commandWord is add.
-        if (commandWord.equals("add")) {
+        if (commandWord.equals(EmailUtil.EMAIL_ADD_COMMAND)) {
             if (MainWindow.getDisplayedBook().equals("candidateBook")) {
                 ObservableList<Candidate> recipients = model.getFilteredCandidateList();
                 for (Candidate recipient : recipients) {
@@ -60,7 +62,7 @@ public class EmailSelectRecipientsCommand extends Command {
             output += EmailSelectRecipientsCommand.MESSAGE_USAGE;
             return new CommandResult(output);
 
-        } else if (commandWord.equals("next")) {
+        } else if (commandWord.equals(EmailUtil.EMAIL_NEXT_COMMAND)) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
 
@@ -81,9 +83,11 @@ public class EmailSelectRecipientsCommand extends Command {
                 return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
             }
         //back command
-        } else {
+        } else if (commandWord.equals(EmailUtil.EMAIL_BACK_COMMAND)) {
             LogicManager.setLogicState(EmailSelectRecipientsCommand.COMMAND_LOGIC_STATE);
             return new CommandResult(EmailSelectRecipientsCommand.MESSAGE_USAGE);
         }
+
+        throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -59,7 +59,7 @@ public class EmailSelectRecipientsCommand extends Command {
                         + model.getFilteredRecipientJobOfferNames()
                         + EmailSelectRecipientsCommand.MESSAGE_USAGE);
             }
-        } else {
+        } else if (commandWord.equals("next")) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
 
@@ -79,6 +79,10 @@ public class EmailSelectRecipientsCommand extends Command {
                 LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
                 return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
             }
+        //back command
+        } else {
+            LogicManager.setLogicState(EmailSelectRecipientsCommand.COMMAND_LOGIC_STATE);
+            return new CommandResult(EmailSelectRecipientsCommand.MESSAGE_USAGE);
         }
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -18,30 +18,42 @@ import seedu.recruit.ui.MainWindow;
  */
 public class EmailSelectRecipientsCommand extends Command {
     public static final String COMMAND_WORD = "next";
-    public static final String MESSAGE_USAGE = "Find the recipients that you are going to email\n "
-            + "Type \"next\" when you have done so to move on to the next step.";
+    public static final String MESSAGE_USAGE = "Find the recipients that you are going to email\n"
+            + "All items listed below will be added into the recipients field.\n"
+            + "Find/Filter the recipients you intend to email, then type \"add\" to add recipients to the field.\n"
+            + "Type \"next\" when you have finished adding recipients to move on to the next step.\n";
     public static final String COMMAND_LOGIC_STATE = "EmailSelectRecipients";
+    private final String commandWord;
+
+    public EmailSelectRecipientsCommand(String commandWord) {
+        this.commandWord = commandWord;
+    }
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        EmailUtil emailUtil = model.getEmailUtil();
 
-        if (MainWindow.getDisplayedBook().equals("candidateBook")) {
-            ObservableList<Candidate> recipients = model.getFilteredCandidateList();
-            for (Candidate recipient : recipients) {
-                emailUtil.addCandidate(recipient);
+        //Add recipients only if commandWord is add.
+        if(commandWord.equals("add")) {
+            EmailUtil emailUtil = model.getEmailUtil();
+
+            if (MainWindow.getDisplayedBook().equals("candidateBook")) {
+                ObservableList<Candidate> recipients = model.getFilteredCandidateList();
+                for (Candidate recipient : recipients) {
+                    emailUtil.addCandidate(recipient);
+                }
+                emailUtil.setAreRecipientsCandidates(true);
+            } else {
+                ObservableList<JobOffer> recipients = model.getFilteredCompanyJobList();
+                for (JobOffer recipient : recipients) {
+                    emailUtil.addJobOffer(recipient);
+                }
+                emailUtil.setAreRecipientsCandidates(false);
             }
-            emailUtil.setAreRecipientsCandidates(true);
+            return new CommandResult("Recipients added!\n" + EmailSelectRecipientsCommand.MESSAGE_USAGE);
         } else {
-            ObservableList<JobOffer> recipients = model.getFilteredCompanyJobList();
-            for (JobOffer recipient : recipients) {
-                emailUtil.addJobOffer(recipient);
-            }
-            emailUtil.setAreRecipientsCandidates(false);
+            LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
+            return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
         }
-
-        LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);
-        return new CommandResult(EmailSelectContentsCommand.MESSAGE_USAGE);
     }
 }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -14,14 +14,15 @@ import seedu.recruit.model.joboffer.JobOffer;
 import seedu.recruit.ui.MainWindow;
 
 /**
- * 2nd step of the Email command
+ * 2nd step of the Email command: selecting recipients
  */
 public class EmailSelectRecipientsCommand extends Command {
     public static final String COMMAND_WORD = "next";
-    public static final String MESSAGE_USAGE = "Find the recipients that you are going to email\n"
+    public static final String MESSAGE_USAGE = "Find/Filter the recipients you intend to email. "
             + "All items listed below will be added into the recipients field.\n"
-            + "Find/Filter the recipients you intend to email, then type \"add\" to add recipients to the field.\n"
-            + "Type \"next\" when you have finished adding recipients to move on to the next step.\n";
+            + "Type \"add\" to add recipients to the field.\n"
+            + "Type \"next\" when you have finished adding recipients to move on to the next step.\n"
+            + "Type \"cancel\" to cancel the email command.";
     public static final String COMMAND_LOGIC_STATE = "EmailSelectRecipients";
     private final String commandWord;
 
@@ -50,15 +51,15 @@ public class EmailSelectRecipientsCommand extends Command {
                 emailUtil.setAreRecipientsCandidates(false);
             }
 
+            String output = "Recipients added:\n";
             if(emailUtil.isAreRecipientsCandidates()) {
-                return new CommandResult("Recipients added:\n"
-                        + model.getFilteredCandidateNames()
-                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+                output += model.getFilteredCandidateNames();
             } else {
-                return new CommandResult("Recipients added:\n"
-                        + model.getFilteredRecipientJobOfferNames()
-                        + EmailSelectRecipientsCommand.MESSAGE_USAGE);
+                output += model.getFilteredRecipientJobOfferNames();
             }
+            output += EmailSelectRecipientsCommand.MESSAGE_USAGE;
+            return new CommandResult(output);
+
         } else if (commandWord.equals("next")) {
             //Check if content array is empty, if it is, do not allow to move on to next stage
             boolean isEmpty = false;
@@ -73,7 +74,7 @@ public class EmailSelectRecipientsCommand extends Command {
             }
 
             if(isEmpty) {
-                return new CommandResult("There are no recipients selected!\n"
+                return new CommandResult("ERROR: There are no recipients selected!\n"
                         + EmailSelectRecipientsCommand.MESSAGE_USAGE);
             } else {
                 LogicManager.setLogicState(EmailSelectContentsCommand.COMMAND_LOGIC_STATE);

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSelectRecipientsCommand.java
@@ -36,7 +36,7 @@ public class EmailSelectRecipientsCommand extends Command {
         EmailUtil emailUtil = model.getEmailUtil();
 
         //Add recipients only if commandWord is add.
-        if(commandWord.equals("add")) {
+        if (commandWord.equals("add")) {
             if (MainWindow.getDisplayedBook().equals("candidateBook")) {
                 ObservableList<Candidate> recipients = model.getFilteredCandidateList();
                 for (Candidate recipient : recipients) {
@@ -52,7 +52,7 @@ public class EmailSelectRecipientsCommand extends Command {
             }
 
             String output = "Recipients added:\n";
-            if(emailUtil.isAreRecipientsCandidates()) {
+            if (emailUtil.isAreRecipientsCandidates()) {
                 output += model.getFilteredCandidateNames();
             } else {
                 output += model.getFilteredRecipientJobOfferNames();
@@ -73,7 +73,7 @@ public class EmailSelectRecipientsCommand extends Command {
                 isEmpty = true;
             }
 
-            if(isEmpty) {
+            if (isEmpty) {
                 return new CommandResult("ERROR: There are no recipients selected!\n"
                         + EmailSelectRecipientsCommand.MESSAGE_USAGE);
             } else {

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
@@ -23,7 +23,7 @@ import seedu.recruit.model.joboffer.JobOffer;
  */
 public class EmailSendCommand extends Command {
     public static final String COMMAND_WORD = "send";
-    public static final String MESSAGE_USAGE = "Type \"send\" to send the message!";
+    public static final String MESSAGE_USAGE = "Type \"send\" to send the message\n";
     public static final String COMMAND_LOGIC_STATE = "EmailSend";
     private static final String EMAIL_SUCCESS = "Successfully sent the email!";
     private static final String EMAIL_FAILURE = "Failed to send the email!";

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
@@ -50,9 +50,7 @@ public class EmailSendCommand extends Command {
         for (Object content : contents) {
             System.out.println(content.toString());
         }
-
         System.out.println("-----------------------------");
-
         for (Object recipient : recipients) {
             System.out.println(recipient.toString());
         }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
@@ -123,7 +123,7 @@ public class EmailSendCommand extends Command {
                                    ArrayList<?> recipients, ArrayList<?> contents) {
         String bodyText;
         if (emailUtil.isAreRecipientsCandidates()) {
-            bodyText = "Hello candidates! I think you will be interested in these job offer(s)\n";
+            bodyText = emailUtil.getEmailSettings().getBodyTextCandidateAsRecipient();
             //contents are companies
             for (Object content : contents) {
                 JobOffer jobOffer = (JobOffer) content;
@@ -139,7 +139,7 @@ public class EmailSendCommand extends Command {
                 jobNames.add(jobOffer.getJob().toString());
             }
 
-            bodyText = "Hello Sirs/Madams,\nI think you will be interested in these candidates for your job offer: "
+            bodyText = emailUtil.getEmailSettings().getBodyTextCompanyAsRecipient()
                     + jobNames.toString() + '\n';
             //contents are candidates
             for (Object content : contents) {
@@ -163,9 +163,9 @@ public class EmailSendCommand extends Command {
     private String generateSubject(EmailUtil emailUtil) {
         String subject;
         if (emailUtil.isAreRecipientsCandidates()) {
-            subject = "Hot new job offers that you will love!";
+            subject = emailUtil.getEmailSettings().getSubjectCandidateAsRecipient();
         } else {
-            subject = "New candidates found for your company!";
+            subject = emailUtil.getEmailSettings().getSubjectCompanyAsRecipient();
         }
         return subject;
     }

--- a/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
+++ b/src/main/java/seedu/recruit/logic/commands/emailcommand/EmailSendCommand.java
@@ -19,11 +19,13 @@ import seedu.recruit.model.company.Company;
 import seedu.recruit.model.joboffer.JobOffer;
 
 /**
- * Finally, send the email.
+ * 4th step of the email command: send the email.
  */
 public class EmailSendCommand extends Command {
     public static final String COMMAND_WORD = "send";
-    public static final String MESSAGE_USAGE = "Type \"send\" to send the message\n";
+    public static final String MESSAGE_USAGE = "Type \"send\" to send the message\n"
+            + "Type \"back\" to go back to select contents command.\n"
+            + "Type \"cancel\" to cancel the email command.";
     public static final String COMMAND_LOGIC_STATE = "EmailSend";
     private static final String EMAIL_SUCCESS = "Successfully sent the email!";
     private static final String EMAIL_FAILURE = "Failed to send the email!";

--- a/src/main/java/seedu/recruit/logic/parser/EmailParser.java
+++ b/src/main/java/seedu/recruit/logic/parser/EmailParser.java
@@ -56,6 +56,9 @@ public class EmailParser {
             case "add":
                 return new EmailSelectContentsCommand(commandWord);
 
+            case "back":
+                return new EmailSelectRecipientsCommand(commandWord);
+
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
@@ -72,6 +75,9 @@ public class EmailParser {
             case "add":
                 return new EmailSelectContentsCommand(commandWord);
 
+            case "back":
+                return new EmailSelectRecipientsCommand(commandWord);
+
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
@@ -82,6 +88,9 @@ public class EmailParser {
 
             case "send":
                 return new EmailSendCommand();
+
+            case "back":
+                return new EmailSelectContentsCommand(commandWord);
 
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/recruit/logic/parser/EmailParser.java
+++ b/src/main/java/seedu/recruit/logic/parser/EmailParser.java
@@ -35,7 +35,10 @@ public class EmailParser {
                 return new ListCommand();
 
             case "next":
-                return new EmailSelectRecipientsCommand();
+                return new EmailSelectRecipientsCommand(commandWord);
+
+            case "add":
+                return new EmailSelectRecipientsCommand(commandWord);
 
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
@@ -47,11 +50,11 @@ public class EmailParser {
                 && emailUtil.isAreRecipientsCandidates()) {
             switch (commandWord) {
 
-            case ListCommand.COMMAND_WORD:
-                return new ListCommand();
-
             case "next":
-                return new EmailSelectContentsCommand();
+                return new EmailSelectContentsCommand(commandWord);
+
+            case "add":
+                return new EmailSelectContentsCommand(commandWord);
 
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
@@ -64,7 +67,10 @@ public class EmailParser {
                 return new ListCommand();
 
             case "next":
-                return new EmailSelectContentsCommand();
+                return new EmailSelectContentsCommand(commandWord);
+
+            case "add":
+                return new EmailSelectContentsCommand(commandWord);
 
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/recruit/logic/parser/EmailParser.java
+++ b/src/main/java/seedu/recruit/logic/parser/EmailParser.java
@@ -1,6 +1,10 @@
 package seedu.recruit.logic.parser;
 
 import static seedu.recruit.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.recruit.commons.util.EmailUtil.EMAIL_ADD_COMMAND;
+import static seedu.recruit.commons.util.EmailUtil.EMAIL_BACK_COMMAND;
+import static seedu.recruit.commons.util.EmailUtil.EMAIL_NEXT_COMMAND;
+import static seedu.recruit.commons.util.EmailUtil.EMAIL_SEND_COMMAND;
 
 import seedu.recruit.commons.util.EmailUtil;
 import seedu.recruit.logic.LogicState;
@@ -34,10 +38,10 @@ public class EmailParser {
             case ListCommand.COMMAND_WORD:
                 return new ListCommand();
 
-            case "next":
+            case EMAIL_NEXT_COMMAND:
                 return new EmailSelectRecipientsCommand(commandWord);
 
-            case "add":
+            case EMAIL_ADD_COMMAND:
                 return new EmailSelectRecipientsCommand(commandWord);
 
             default:
@@ -50,13 +54,13 @@ public class EmailParser {
                 && emailUtil.isAreRecipientsCandidates()) {
             switch (commandWord) {
 
-            case "next":
+            case EMAIL_NEXT_COMMAND:
                 return new EmailSelectContentsCommand(commandWord);
 
-            case "add":
+            case EMAIL_ADD_COMMAND:
                 return new EmailSelectContentsCommand(commandWord);
 
-            case "back":
+            case EMAIL_BACK_COMMAND:
                 return new EmailSelectRecipientsCommand(commandWord);
 
             default:
@@ -69,13 +73,13 @@ public class EmailParser {
             case ListCommand.COMMAND_WORD:
                 return new ListCommand();
 
-            case "next":
+            case EMAIL_NEXT_COMMAND:
                 return new EmailSelectContentsCommand(commandWord);
 
-            case "add":
+            case EMAIL_ADD_COMMAND:
                 return new EmailSelectContentsCommand(commandWord);
 
-            case "back":
+            case EMAIL_BACK_COMMAND:
                 return new EmailSelectRecipientsCommand(commandWord);
 
             default:
@@ -86,16 +90,17 @@ public class EmailParser {
         } else if (state.nextCommand.equals(EmailSendCommand.COMMAND_LOGIC_STATE)) {
             switch (commandWord) {
 
-            case "send":
+            case EMAIL_SEND_COMMAND:
                 return new EmailSendCommand();
 
-            case "back":
+            case EMAIL_BACK_COMMAND:
                 return new EmailSelectContentsCommand(commandWord);
 
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
-        } else {
+        }
+        else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/main/java/seedu/recruit/logic/parser/EmailParser.java
+++ b/src/main/java/seedu/recruit/logic/parser/EmailParser.java
@@ -99,8 +99,7 @@ public class EmailParser {
             default:
                 throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
             }
-        }
-        else {
+        } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }

--- a/src/main/java/seedu/recruit/model/Model.java
+++ b/src/main/java/seedu/recruit/model/Model.java
@@ -186,7 +186,30 @@ public interface Model {
      */
     void updateFilteredCompanyJobList(Predicate<JobOffer> predicate);
 
+    // ================================== Email Command functions ===================================== //
+
+    /**
+     * Returns emailUtil in model
+     */
     EmailUtil getEmailUtil();
 
+    /**
+     * Setter for emailUtil in model
+     */
     void setEmailUtil(EmailUtil emailUtil);
+
+    /**
+     * Returns a concatenated string of names of job offers for email select recipients command
+     */
+    String getFilteredRecipientJobOfferNames();
+
+    /**
+     * Returns a concatendated string of names of job offers for email select contents command
+     */
+    String getFilteredContentJobOfferNames();
+
+    /**
+     * Returns a concatenated string of names of candidates for email command
+     */
+    String getFilteredCandidateNames();
 }

--- a/src/main/java/seedu/recruit/model/ModelManager.java
+++ b/src/main/java/seedu/recruit/model/ModelManager.java
@@ -312,7 +312,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public String getFilteredRecipientJobOfferNames() {
         StringBuilder output = new StringBuilder();
-        for(JobOffer jobOffer : filteredJobs) {
+        for (JobOffer jobOffer : filteredJobs) {
             output.append(jobOffer.getCompanyName().toString());
             output.append(" regarding job offer: ");
             output.append(jobOffer.getJob().toString());
@@ -327,7 +327,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public String getFilteredContentJobOfferNames() {
         StringBuilder output = new StringBuilder();
-        for(JobOffer jobOffer : filteredJobs) {
+        for (JobOffer jobOffer : filteredJobs) {
             output.append(jobOffer.getJob().toString());
             output.append(" at ");
             output.append(jobOffer.getCompanyName().toString());
@@ -342,7 +342,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public String getFilteredCandidateNames() {
         StringBuilder output = new StringBuilder();
-        for(Candidate candidate : filteredCandidates) {
+        for (Candidate candidate : filteredCandidates) {
             output.append(candidate.getName().toString());
             output.append("\n");
         }

--- a/src/main/java/seedu/recruit/model/ModelManager.java
+++ b/src/main/java/seedu/recruit/model/ModelManager.java
@@ -10,7 +10,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.recruit.commons.core.ComponentManager;
-import seedu.recruit.commons.core.EmailSettings;
 import seedu.recruit.commons.core.LogsCenter;
 import seedu.recruit.commons.events.model.CandidateBookChangedEvent;
 import seedu.recruit.commons.events.model.CompanyBookChangedEvent;

--- a/src/main/java/seedu/recruit/model/ModelManager.java
+++ b/src/main/java/seedu/recruit/model/ModelManager.java
@@ -296,11 +296,56 @@ public class ModelManager extends ComponentManager implements Model {
         filteredJobs.setPredicate(predicate);
     }
 
+    // ================================== Email Command functions ===================================== //
+
     public EmailUtil getEmailUtil() {
         return emailUtil;
     }
 
     public void setEmailUtil(EmailUtil emailUtil) {
         this.emailUtil = emailUtil;
+    }
+
+    /**
+     * Returns a concatenated string of names of job offers for email select recipients command
+     */
+    @Override
+    public String getFilteredRecipientJobOfferNames() {
+        StringBuilder output = new StringBuilder();
+        for(JobOffer jobOffer : filteredJobs) {
+            output.append(jobOffer.getCompanyName().toString());
+            output.append(" regarding job offer: ");
+            output.append(jobOffer.getJob().toString());
+            output.append("\n");
+        }
+        return output.toString();
+    }
+
+    /**
+     * Returns a concatenated string of names of job offers for email select contents command
+     */
+    @Override
+    public String getFilteredContentJobOfferNames() {
+        StringBuilder output = new StringBuilder();
+        for(JobOffer jobOffer : filteredJobs) {
+            output.append(jobOffer.getJob().toString());
+            output.append(" at ");
+            output.append(jobOffer.getCompanyName().toString());
+            output.append("\n");
+        }
+        return output.toString();
+    }
+    
+    /**
+     * Returns a concatenated string of names of candidates for email command
+     */
+    @Override
+    public String getFilteredCandidateNames() {
+        StringBuilder output = new StringBuilder();
+        for(Candidate candidate : filteredCandidates) {
+            output.append(candidate.getName().toString());
+            output.append("\n");
+        }
+        return output.toString();
     }
 }

--- a/src/main/java/seedu/recruit/model/ModelManager.java
+++ b/src/main/java/seedu/recruit/model/ModelManager.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.recruit.commons.core.ComponentManager;
+import seedu.recruit.commons.core.EmailSettings;
 import seedu.recruit.commons.core.LogsCenter;
 import seedu.recruit.commons.events.model.CandidateBookChangedEvent;
 import seedu.recruit.commons.events.model.CompanyBookChangedEvent;
@@ -47,7 +48,7 @@ public class ModelManager extends ComponentManager implements Model {
         filteredCandidates = new FilteredList<>(versionedCandidateBook.getCandidateList());
         filteredCompanies = new FilteredList<>(versionedCompanyBook.getCompanyList());
         filteredJobs = new FilteredList<>(versionedCompanyBook.getCompanyJobList());
-        emailUtil = new EmailUtil();
+        emailUtil = new EmailUtil(userPrefs.getEmailSettings());
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/recruit/model/ModelManager.java
+++ b/src/main/java/seedu/recruit/model/ModelManager.java
@@ -42,12 +42,13 @@ public class ModelManager extends ComponentManager implements Model {
 
         logger.fine("Initializing with recruit book: " + candidateBook + " and user prefs " + userPrefs);
 
+        EmailUtil.setEmailSettings(userPrefs.getEmailSettings());
         versionedCandidateBook = new VersionedCandidateBook(candidateBook);
         versionedCompanyBook = new VersionedCompanyBook(companyBook);
         filteredCandidates = new FilteredList<>(versionedCandidateBook.getCandidateList());
         filteredCompanies = new FilteredList<>(versionedCompanyBook.getCompanyList());
         filteredJobs = new FilteredList<>(versionedCompanyBook.getCompanyJobList());
-        emailUtil = new EmailUtil(userPrefs.getEmailSettings());
+        emailUtil = new EmailUtil();
     }
 
     public ModelManager() {

--- a/src/main/java/seedu/recruit/model/ModelManager.java
+++ b/src/main/java/seedu/recruit/model/ModelManager.java
@@ -335,7 +335,7 @@ public class ModelManager extends ComponentManager implements Model {
         }
         return output.toString();
     }
-    
+
     /**
      * Returns a concatenated string of names of candidates for email command
      */

--- a/src/main/java/seedu/recruit/model/UserPrefs.java
+++ b/src/main/java/seedu/recruit/model/UserPrefs.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
+import seedu.recruit.commons.core.EmailSettings;
 import seedu.recruit.commons.core.GuiSettings;
 
 /**
@@ -12,6 +13,7 @@ import seedu.recruit.commons.core.GuiSettings;
 public class UserPrefs {
 
     private GuiSettings guiSettings;
+    private final EmailSettings emailSettings = new EmailSettings();
     private Path candidateBookFilePath = Paths.get("data" , "candidatebook.xml");
     private Path companyBookFilePath = Paths.get("data" , "companybook.xml");
 
@@ -29,6 +31,10 @@ public class UserPrefs {
 
     public void setGuiSettings(double width, double height, int x, int y) {
         guiSettings = new GuiSettings(width, height, x, y);
+    }
+
+    public EmailSettings getEmailSettings() {
+        return emailSettings;
     }
 
     public Path getCandidateBookFilePath() {
@@ -72,6 +78,7 @@ public class UserPrefs {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings.toString());
+        sb.append("\nEmail Settings : " + emailSettings.toString());
         sb.append("\nLocal candidatebook file location : " + candidateBookFilePath);
         sb.append("\nLocal companybook file location : " + companyBookFilePath);
         return sb.toString();

--- a/src/test/java/seedu/recruit/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/recruit/logic/commands/CommandTestUtil.java
@@ -27,6 +27,7 @@ import seedu.recruit.commons.util.EmailUtil;
 import seedu.recruit.logic.CommandHistory;
 import seedu.recruit.logic.commands.exceptions.CommandException;
 import seedu.recruit.logic.parser.Prefix;
+import seedu.recruit.logic.parser.exceptions.ParseException;
 import seedu.recruit.model.CandidateBook;
 import seedu.recruit.model.Model;
 import seedu.recruit.model.ReadOnlyCandidateBook;
@@ -149,7 +150,7 @@ public class CommandTestUtil {
             assertEquals(expectedMessage, result.feedbackToUser);
             assertEquals(expectedModel, actualModel);
             assertEquals(expectedCommandHistory, actualCommandHistory);
-        } catch (IOException | GeneralSecurityException | CommandException ce) {
+        } catch (IOException | GeneralSecurityException | CommandException | ParseException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }
     }
@@ -173,7 +174,7 @@ public class CommandTestUtil {
         try {
             command.execute(actualModel, actualCommandHistory);
             throw new AssertionError("The expected CommandException was not thrown.");
-        } catch (IOException | GeneralSecurityException | CommandException e) {
+        } catch (IOException | GeneralSecurityException | CommandException | ParseException e) {
             assertEquals(expectedMessage, e.getMessage());
             assertEquals(expectedCandidateBook, actualModel.getCandidateBook());
             assertEquals(expectedFilteredList, actualModel.getFilteredCandidateList());

--- a/src/test/java/seedu/recruit/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/recruit/logic/commands/CommandTestUtil.java
@@ -378,5 +378,20 @@ public class CommandTestUtil {
         public void setEmailUtil(EmailUtil emailUtil) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public String getFilteredRecipientJobOfferNames() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String getFilteredContentJobOfferNames() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public String getFilteredCandidateNames() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 }

--- a/src/test/java/seedu/recruit/logic/parser/RecruitBookParserTest.java
+++ b/src/test/java/seedu/recruit/logic/parser/RecruitBookParserTest.java
@@ -14,7 +14,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import seedu.recruit.commons.core.EmailSettings;
 import seedu.recruit.commons.util.EmailUtil;
 import seedu.recruit.logic.LogicState;
 import seedu.recruit.logic.commands.AddCandidateCommand;
@@ -44,10 +43,7 @@ public class RecruitBookParserTest {
 
     // dummy LogicState stub
     private LogicState state = new LogicState("primary");
-    // dummy emailsettings stub
-    private EmailSettings emailSettings = new EmailSettings();
-    private EmailUtil emailUtil = new EmailUtil(emailSettings);
-
+    private EmailUtil emailUtil = new EmailUtil();
     private final RecruitBookParser parser = new RecruitBookParser();
 
     @Test

--- a/src/test/java/seedu/recruit/logic/parser/RecruitBookParserTest.java
+++ b/src/test/java/seedu/recruit/logic/parser/RecruitBookParserTest.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.recruit.commons.core.EmailSettings;
 import seedu.recruit.commons.util.EmailUtil;
 import seedu.recruit.logic.LogicState;
 import seedu.recruit.logic.commands.AddCandidateCommand;
@@ -43,7 +44,9 @@ public class RecruitBookParserTest {
 
     // dummy LogicState stub
     private LogicState state = new LogicState("primary");
-    private EmailUtil emailUtil = new EmailUtil();
+    // dummy emailsettings stub
+    private EmailSettings emailSettings = new EmailSettings();
+    private EmailUtil emailUtil = new EmailUtil(emailSettings);
 
     private final RecruitBookParser parser = new RecruitBookParser();
 


### PR DESCRIPTION
What's new?
- Added back/next commands to go back and forth within email command
- Added add command to add whichever persons are listed on the page
- Added messages to show who/what has been added 
- Customisation of subject title and body text of emails. Can be changed in preference.json file in root.

TODO:
- [ ] Add functionality with filter/find function
- [ ] Add a preview of the email in send stage of email
- [ ] Test cases
- [ ] User Guide
- [ ] Developer Guide